### PR TITLE
Making forge run anywhere

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -59,7 +59,7 @@ def instance_metadata(item):
     """ Returns information about the current instance from EC2 Instace API """
     try:
         import httplib
-        api = httplib.HTTPConnection('169.254.169.254')
+        api = httplib.HTTPConnection('169.254.169.254', timeout=10)
         api.request('GET', '/latest/meta-data/' + item)
         metadata = api.getresponse().read()
         api.close()

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -108,7 +108,7 @@ def applicable_playbooks():
     """ Returns a list of playbooks that should be applied to this system """
     playbooks = ['']                  # Base Playbook
     playbooks.append(project_path())  # Project Playbook
-    playbooks.extend(role_paths())    # System Roles
+    playbooks.append(role_paths())    # System Roles
     return sorted(unique(playbooks), key=len)
 
 

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -164,9 +164,9 @@ def configure_environment():
     """ Exposes information from Resource Tags in Ansible vars """
     get_vault('')
     with open('/etc/ansible/group_vars/local.yml', 'w+') as stream:
-        stream.write("\nproject: " + resource_tags()['Project'])
-        stream.write("\nenvironment_tier: " + resource_tags()['Environment'])
-        stream.write("\nsystem_role: " + resource_tags()['Role'])
+        stream.write("\nproject: " + detect('Project'))
+        stream.write("\nenvironment_tier: " + detect('Environment'))
+        stream.write("\nsystem_role: " + detect('Role'))
 
 
 def record_exit(playbook, exit_status):

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -32,7 +32,7 @@ def install_with_pip(packages):
 def detect(setting):
     """ Detects a setting in tags, falls back to environment variables """
     import os
-    if resource_tags() is not None setting in resource_tags():
+    if resource_tags() is not None and setting in resource_tags():
         return resource_tags()[setting]
     else:
         return os.getenv(shell_style(setting))

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -32,7 +32,7 @@ def install_with_pip(packages):
 def detect(setting):
     """ Detects a setting in tags, falls back to environment variables """
     import os
-    if setting in resource_tags():
+    if resource_tags() is not None setting in resource_tags():
         return resource_tags()[setting]
     else:
         return os.getenv(shell_style(setting))

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -57,12 +57,15 @@ def download_from_s3(source, destination):
 
 def instance_metadata(item):
     """ Returns information about the current instance from EC2 Instace API """
-    import httplib
-    api = httplib.HTTPConnection('169.254.169.254')
-    api.request('GET', '/latest/meta-data/' + item)
-    metadata = api.getresponse().read()
-    api.close()
-    return metadata
+    try:
+        import httplib
+        api = httplib.HTTPConnection('169.254.169.254')
+        api.request('GET', '/latest/meta-data/' + item)
+        metadata = api.getresponse().read()
+        api.close()
+        return metadata
+    except:
+        pass
 
 
 def instance_id():
@@ -77,10 +80,13 @@ def region():
 
 def resource_tags():
     """ Returns a dictionary of all resource tags for the current instance """
-    import boto.ec2
-    api = boto.ec2.connect_to_region(region())
-    tags = api.get_all_tags(filters={'resource-id': instance_id()})
-    return {tag.name: tag.value for tag in tags}
+    try:
+        import boto.ec2
+        api = boto.ec2.connect_to_region(region())
+        tags = api.get_all_tags(filters={'resource-id': instance_id()})
+        return {tag.name: tag.value for tag in tags}
+    except:
+        pass
 
 
 def security_groups():


### PR DESCRIPTION
Previously, I have been unable to run forge on any box outside of AWS. Forge supports `ENV` vars, but whenever I tried used just `ENV` vars, I kept failing out. 

The changes I made still work on AWS, but forge can now also be used outside of AWS. I've tested the changes inside of AWS to make sure the original functionality was still there and everything worked.

You can test it out yourself on any forge enabled AWS box by ammending the file at `/usr/local/sbin/reforge` to be

```
#!/bin/sh

curl https://raw.githubusercontent.com/noqcks/forge/master/bootstrap.py | python
```

and running `sudo reforge`.

The only difference when running forge on a machine outside of AWS, is that the following `ENV` vars will need to be added to your env.

```
FORGE_REGION
FORGE_BUCKET
ENVIRONMENT
PROJECT
ROLE
```

Forge usually infers these from EC2 instance tags. 

@telusdigital/guild-devops plz review :100: 
