### PR TITLE
Fix version pinning

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -248,7 +248,7 @@ def get_credentials():
 
 def preconfigure():
     """ Configure everything needed to configure everything else. """
-    install_with_pip(['ansible<2', 'awscli', 'boto'])
+    install_with_pip(['"ansible<2"', 'awscli', 'boto'])
     configure_ansible()
     configure_environment()
     get_credentials()


### PR DESCRIPTION
Because this uses `subprocess.call()`, the `<2` is read as "read STDIN from file `2`, which doesn't exist. This fixes that.
