### PR TITLE
Add libffi-dev to packages.

### DIFF
--- a/examples/cloud-init
+++ b/examples/cloud-init
@@ -6,5 +6,6 @@ packages:
  - python-dev
  - python-pip
  - git
+ - libffi-dev
 runcmd:
  - curl https://raw.githubusercontent.com/telusdigital/forge/master/bootstrap.py | python


### PR DESCRIPTION
`paramiko 2.0.0` (released today) needs this to work.
