### PR TITLE
Add skipping the role playbook with forge. Also check for a playbook existing before trying to execute it.

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -143,7 +143,8 @@ def applicable_playbooks():
       playbooks.append(project_path())
 
     # System Roles Playbook
-    playbooks.extend(role_paths())
+    if not args.skip_role_playbook:
+      playbooks.extend(role_paths())
 
     return sorted(unique(playbooks), key=len)
 


### PR DESCRIPTION
A big win: no more angry red text from ansible-playbook about playbooks not being found (this all comes from there not being pre and post playbooks for everything.)

Makes it really easy to roll out auth updates for a host.
Tested on the workspace hosts with:
`reforge --skip-role-playbook --skip-base-playbook --skip-preconfigure`

Here's how to create a bash function to test the changes without affecting a system.  You need to do this as root:

```
reforge () { curl https://raw.githubusercontent.com/telusdigital/forge/fb_skip-role-playbook/bootstrap.py | python - $*;}
```
